### PR TITLE
Fixed exercise not being printed when an item from the menu is selected (issue #17)

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -19,7 +19,5 @@ var lessons = [
   { title: 'QUOTES', file: './problems/quotes' },
   { title: 'BLINK', file: './problems/blink' }
 ]
-lessons.forEach(function (lesson) {
-  shop.add(lesson.title, function () { return require(lesson.file) })
-})
+lessons.map(({title, file}) => ({title, file: require(file)})).forEach(({title, file}) => shop.add(title, () => file))
 shop.execute(process.argv.slice(2))

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "substack",
   "license": "MIT",
   "dependencies": {
-    "adventure": "^2.10.0",
+    "adventure": "^2.11.1",
     "adventure-verify": "^2.2.0"
   },
   "keywords": [


### PR DESCRIPTION
Fixed the problem with the exercise not being printed when an item from the menu is selected due to `require` being called in the wrong context. The error mentioned in the issue #17 still happens because of an error in the adventure package (fixed in version 2.11.2). 